### PR TITLE
Make artifact server stoppable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+bin
+build
+testbin/*
+Dockerfile.cross
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Kubernetes Generated files - skip generated files, except for vendored files
+
+!vendor/**/zz_generated.*
+
+# editor and IDE paraphernalia
+go.work
+go.work.sum
+.idea
+*.swp
+*.swo
+*~
+
+# goreleaser resources
+dist/
+output/

--- a/server/server.go
+++ b/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -58,8 +57,7 @@ func (s *ArtifactServer) Start(ctx context.Context) error {
 		err = s.server.Shutdown(ctx)
 	case err = <-serverErr:
 	}
-	if errors.Is(err, http.ErrServerClosed) {
-		return nil
-	}
+
+	// serverErrs that occur after Shutdown is called are currently ignored.
 	return err
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -11,21 +12,50 @@ import (
 	"github.com/openfluxcd/controller-manager/storage"
 )
 
-type StartServer func(path, address string) error
-
-// InitializeStorage creates a storage and returns the means to launch a file server to serve created Artifacts.
-func InitializeStorage(c client.Client, scheme *runtime.Scheme, path, storageAddress string, artifactRetentionTTL time.Duration, artifactRetentionRecords int) (StartServer, *storage.Storage, error) {
+// NewStorage creates a storage and returns the means to launch a file server to serve created Artifacts.
+func NewStorage(c client.Client, scheme *runtime.Scheme, path, storageAddress string, artifactRetentionTTL time.Duration, artifactRetentionRecords int) (*storage.Storage, error) {
 	stg, err := storage.NewStorage(c, scheme, path, storageAddress, artifactRetentionTTL, artifactRetentionRecords)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error initializing storage: %v", err)
+		return nil, fmt.Errorf("error initializing storage: %v", err)
 	}
 
-	return startFileServer, stg, nil
+	return stg, nil
 }
 
-func startFileServer(path string, address string) error {
+type ArtifactServer struct {
+	*http.Server
+	timeout time.Duration
+}
+
+func NewArtifactServer(path string, address string, timeout time.Duration) (*ArtifactServer, error) {
 	fs := http.FileServer(http.Dir(path))
 	mux := http.NewServeMux()
 	mux.Handle("/", fs)
-	return http.ListenAndServe(address, mux)
+
+	s := &http.Server{
+		Addr:    address,
+		Handler: mux,
+	}
+	as := &ArtifactServer{
+		Server:  s,
+		timeout: timeout,
+	}
+	return as, nil
+}
+
+func (s *ArtifactServer) Start(ctx context.Context) error {
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- s.ListenAndServe()
+	}()
+	var err error
+	var cancel context.CancelFunc
+	select {
+	case <-ctx.Done():
+		ctx, cancel = context.WithTimeout(context.Background(), s.timeout)
+		defer cancel()
+		err = s.Shutdown(ctx)
+	case err = <-serverErr:
+	}
+	return err
 }

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -56,6 +57,9 @@ func (s *ArtifactServer) Start(ctx context.Context) error {
 		defer cancel()
 		err = s.server.Shutdown(ctx)
 	case err = <-serverErr:
+	}
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
 	}
 	return err
 }


### PR DESCRIPTION
This PR does some clean up and makes the server stoppable. This is necessary in order for tests that have to start such a server as a prerequisite to finish.