### PR TITLE
fix: also set controller ref

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -134,7 +134,7 @@ func (s Storage) ReconcileArtifact(ctx context.Context, obj Collectable, revisio
 	createArtifact := curArtifact.DeepCopy()
 	if _, err = controllerutil.CreateOrUpdate(ctx, s.kclient, createArtifact, func() error {
 		if createArtifact.ObjectMeta.CreationTimestamp.IsZero() {
-			if err := controllerutil.SetOwnerReference(obj, createArtifact, s.scheme); err != nil {
+			if err := controllerutil.SetControllerReference(obj, createArtifact, s.scheme); err != nil {
 				return fmt.Errorf("failed to set owner reference: %w", err)
 			}
 		}


### PR DESCRIPTION
this will block owner deletion of artifact owners correctly as previously this was missing. This can cause artifacts to be orphaned.