### PR TITLE
Check if artifact exists in the storage on the filesystem

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -99,15 +99,16 @@ func (s Storage) ReconcileArtifact(ctx context.Context, obj Collectable, revisio
 	// The artifact is up-to-date
 	// Since digest is set by the end of reconciling an artifact,
 	// we'll know if the artifact was created anew or if it already existed.
-	if HasRevision(curArtifact, revision) {
+	if s.ArtifactExist(*curArtifact) && HasRevision(curArtifact, revision) {
 		return nil
+
 	}
 
 	// We don't need to check this here...
 	// Create potential new artifact with current available metadata
 	artifact := s.NewArtifactFor(obj.GetKind(), obj.GetObjectMeta(), revision, filename)
 
-	curArtifact = artifact.DeepCopy()
+	curArtifact = &artifact
 
 	// Ensure target path exists and is a directory
 	if f, err := os.Stat(dir); err != nil {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -107,7 +107,7 @@ func (s Storage) ReconcileArtifact(ctx context.Context, obj Collectable, revisio
 	// Create potential new artifact with current available metadata
 	artifact := s.NewArtifactFor(obj.GetKind(), obj.GetObjectMeta(), revision, filename)
 
-	curArtifact = &artifact
+	curArtifact = artifact.DeepCopy()
 
 	// Ensure target path exists and is a directory
 	if f, err := os.Stat(dir); err != nil {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -99,9 +99,8 @@ func (s Storage) ReconcileArtifact(ctx context.Context, obj Collectable, revisio
 	// The artifact is up-to-date
 	// Since digest is set by the end of reconciling an artifact,
 	// we'll know if the artifact was created anew or if it already existed.
-	if s.ArtifactExist(*curArtifact) && HasRevision(curArtifact, revision) {
+	if curArtifact != nil && s.ArtifactExist(*curArtifact) && HasRevision(curArtifact, revision) {
 		return nil
-
 	}
 
 	// We don't need to check this here...


### PR DESCRIPTION
if we don't check this, the resource artifact could exist while the artifact on the filesystem is missing. This would lead to no error but also to not reconcile the artifact. This is an non-recoverable state. Thus, the change is required.