### PR TITLE
chore: allow multiple owners of artifacts

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -819,7 +819,6 @@ func (s *Storage) LocalPathFromURL(artifact *v1.Artifact) string {
 	return actualFilePath
 }
 
-// this should most likely be extracted into the controller-manager
 func (s *Storage) findArtifact(ctx context.Context, object client.Object) (*v1.Artifact, error) {
 	// this should look through ALL the artifacts and look if the owner is THIS object.
 	list := &v1.ArtifactList{}
@@ -828,11 +827,6 @@ func (s *Storage) findArtifact(ctx context.Context, object client.Object) (*v1.A
 	}
 
 	for _, artifact := range list.Items {
-		if len(artifact.GetOwnerReferences()) != 1 {
-			// ignore artifacts with multiple owners -> this should throw an error?
-			continue
-		}
-
 		for _, owner := range artifact.OwnerReferences {
 			if owner.Name == object.GetName() {
 				return &artifact, nil


### PR DESCRIPTION
This allows multiple artifact owners so that multiple CRDs can reference the artifact for being used as a source ref:

Example:
```
apiVersion: delivery.ocm.software/v1alpha1
kind: LocalizedResource
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"delivery.ocm.software/v1alpha1","kind":"LocalizedResource","metadata":{"annotations":{},"labels":{"app.kubernetes.io/managed-by":"kustomize","app.kubernetes.io/name":"ocm-k8s-toolkit"},"name":"localized-resource-sample","namespace":"default"},"spec":{"config":{"kind":"Resource","name":"resource-localization-instruction"},"interval":"10m","target":{"kind":"Resource","name":"resource-sample"}}}
  creationTimestamp: "2024-10-28T13:56:18Z"
  finalizers:
  - finalizers.ocm.software/artifact
  generation: 4
  labels:
    app.kubernetes.io/managed-by: kustomize
    app.kubernetes.io/name: ocm-k8s-toolkit
  name: localized-resource-sample
  namespace: default
  resourceVersion: "1089978"
  uid: 9bf0c308-30f6-462b-a269-6ce043be0939
spec:
  config:
    apiVersion: delivery.ocm.software/v1alpha1
    kind: Resource
    name: resource-localization-instruction
    namespace: default
  interval: 10m0s
  target:
    apiVersion: delivery.ocm.software/v1alpha1
    kind: Resource
    name: resource-sample
    namespace: default
status:
  artifactRef:
    name: configuredresource-default-localized-resource-sample
    namespace: default
  conditions:
  - lastTransitionTime: "2024-10-28T13:59:37Z"
    message: localized successfully
    observedGeneration: 4
    reason: Succeeded
    status: "True"
    type: Ready
  configuredResourceRef:
    name: localized-resource-sample
    namespace: default
  digest: sha256:35ebf19cbac575bf4253bf3015cc91fa66d20d4a315281b374c67493b88fd2b8
  observedGeneration: 4
---
apiVersion: openfluxcd.mandelsoft.org/v1alpha1
kind: Artifact
metadata:
  annotations:
    ocm.software/artifact-purpose: localization
    ocm.software/localization: default/localized-resource-sample
  creationTimestamp: "2024-10-28T13:59:37Z"
  generation: 1
  name: configuredresource-default-localized-resource-sample
  namespace: default
  ownerReferences:
  - apiVersion: delivery.ocm.software/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: ConfiguredResource
    name: localized-resource-sample
    uid: 3427c828-1d05-4f4a-9d09-bdcd266147e8
  - apiVersion: delivery.ocm.software/v1alpha1
    kind: LocalizedResource
    name: localized-resource-sample
    uid: 9bf0c308-30f6-462b-a269-6ce043be0939
  resourceVersion: "1089973"
  uid: b1b2e639-6abe-4df5-a320-158593187d2e
spec:
  digest: sha256:ee5a66ce2feaf4a659b112499a39ee71e78296a306111bcaf6c182580ac05379
  lastUpdateTime: "2024-10-28T13:59:37Z"
  revision: artifact resource-default-resource-sample in revision b5cd3f284a697782bd8808569738ae7db2eea5537d9744734d663c188148ad27
    (from resource resource-sample, based on component podinfo-component) configured
    with default/localized-resource-sample in generation 1
  size: 13937
  url: http:///configuredresource/default/localized-resource-sample/sha256_35ebf19cbac575bf4253bf3015cc91fa66d20d4a315281b374c67493b88fd2b8.tar.gz

```